### PR TITLE
Authenticate middleware redirect should return null for JSON requests

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -14,8 +14,6 @@ final class Authenticate extends Middleware
      */
     protected function redirectTo(Request $request): ?string
     {
-        if (! $request->expectsJson()) {
-            return route('login');
-        }
+        return $request->expectsJson() ? null : route('login');
     }
 }


### PR DESCRIPTION
The `redirectTo()` function wasn’t returning `null` for JSON requests causing it to throw a 500 error for unauthenticated API requests.